### PR TITLE
Ignore empty Credentials for Qlik Sense Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ or
 For the usage just have a look to the further documentation.
 
 1. [PS Examples](docs/PS_Examples.md)
-2. [Working with Signatures](docs/Signature.md)
+2. [Install](docs/install.md)
+3. [Working with Signatures](docs/Signature.md)
+4. [Working with Remoting](docs/SetupPowerShellRemoting.md)
+5. [Versions](docs/Version.md)
 
 ## Bugs & Co.
 

--- a/src/QlikConnectorPSExecute/PSExecuteConnection.cs
+++ b/src/QlikConnectorPSExecute/PSExecuteConnection.cs
@@ -108,6 +108,8 @@ namespace QlikConnectorPSExecute
 
         private QvxTable GetData(ScriptCode script, string username, string password, string workdir, string remoteName)
         {
+            Thread.Sleep(10000);
+
             var actualWorkDir = Environment.CurrentDirectory;
             var useRemote = IsRemoteComputer(remoteName);
 
@@ -201,7 +203,7 @@ namespace QlikConnectorPSExecute
                                                         WindowsGrandAccess.WindowStationAllAccess,
                                                         WindowsGrandAccess.DesktopRightsAllAccess))
                     {
-                        using (var interactiveUser = new InteractiveUser(accountInfo))
+                        using (var interactiveUser = new InteractiveUser(accountInfo, IsQlikDesktopApp))
                         {
                             // Run PowerShell
                             var results = powerShell.Invoke();

--- a/src/QlikConnectorPSExecute/PSExecuteConnection.cs
+++ b/src/QlikConnectorPSExecute/PSExecuteConnection.cs
@@ -108,8 +108,6 @@ namespace QlikConnectorPSExecute
 
         private QvxTable GetData(ScriptCode script, string username, string password, string workdir, string remoteName)
         {
-            Thread.Sleep(10000);
-
             var actualWorkDir = Environment.CurrentDirectory;
             var useRemote = IsRemoteComputer(remoteName);
 

--- a/src/QlikConnectorPSExecute/UserInteractive.cs
+++ b/src/QlikConnectorPSExecute/UserInteractive.cs
@@ -176,10 +176,18 @@ namespace QlikConnectorPSExecute
                     throw new Win32Exception((int)winErrorCode, $"LsaEnumerateAccountRights failed: {winErrorCode}");
                 }
 
-                var newPtr = new IntPtr(userRightsPtr.ToInt32());
-                if (IntPtr.Size == 8)
+                var newPtr = IntPtr.Zero;
+                try
+                {
+                    newPtr = new IntPtr(userRightsPtr.ToInt32());
+                    if (IntPtr.Size == 8)
+                        newPtr = new IntPtr(userRightsPtr.ToInt64());
+                }
+                catch
+                {
                     newPtr = new IntPtr(userRightsPtr.ToInt64());
-
+                }
+                
                 LSA_UNICODE_STRING userRight;
 
                 int ptr = 0;
@@ -264,10 +272,13 @@ namespace QlikConnectorPSExecute
         #endregion
 
         #region Constructor
-        public InteractiveUser(NTAccount accountInfo)
+        public InteractiveUser(NTAccount accountInfo, bool IsQlikDesktop)
         {
             try
             {
+                if (accountInfo == null && IsQlikDesktop == true)
+                    return;
+
                 if (String.IsNullOrEmpty(CurrentRight))
                     CurrentRight = LocalSecurityAuthorityRights.InteractiveLogon;
 


### PR DESCRIPTION
Run with empty Credentials for Qlik Sense Desktop.